### PR TITLE
Update build.gradle

### DIFF
--- a/flutter_auth_ui/android/build.gradle
+++ b/flutter_auth_ui/android/build.gradle
@@ -46,5 +46,5 @@ android {
 }
 
 dependencies {
-    implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
+    implementation 'com.firebaseui:firebase-ui-auth:8.0.2'
 }


### PR DESCRIPTION
The "Requires IMMUTABLE tag crash on API 31" has been fixed in 8.0.2 (https://github.com/firebase/FirebaseUI-Android/pull/2063). Is it possible this package is updated to that dependency?